### PR TITLE
Fix error with trailing @sedbot

### DIFF
--- a/sedbot.sh
+++ b/sedbot.sh
@@ -12,7 +12,7 @@ do
     echo "${update}"
     echo
     if [[ "${text}" == /sed* ]] && [[ "${username}" != stream_editor_bot ]]; then
-      sed_cmd="${text:5}"
+      sed_cmd="${text#* }"
       reply_to_message_text=$(echo ${update} | jq -r ".message.reply_to_message.text")
       sed_result=$(echo "${reply_to_message_text}" | sed --posix "${sed_cmd}" 2>&1)
       sed_return_code=$?


### PR DESCRIPTION
Changed the string substitution from hardcoded length 5 (`/sed[space]`) to "remove shortest substring from beginning (with `#`) ending with `[space]`". The shortest substring will either be `/sed[space]` or `/sed@botname[space]`.